### PR TITLE
Implemented toJson and fromJson for date and time types

### DIFF
--- a/lib/src/annual_date.dart
+++ b/lib/src/annual_date.dart
@@ -36,6 +36,23 @@ class AnnualDate implements Comparable<AnnualDate> {
     GregorianYearMonthDayCalculator.validateGregorianYearMonthDay(2000, month, day);
   }
 
+  /// Constructs an instance for the given string with format MM-dd, in the ISO calendar.
+  ///
+  /// * [s]: The string to parse.
+  ///
+  /// * [FormatException]: The string is not in the correct format.
+  /// * [ArgumentOutOfRangeException]: The parameters do not form a valid date.
+  /// (February 29th is considered valid.)
+  factory AnnualDate.parse(String s) {
+    var parts = s.split('-');
+    if (parts.length != 2) {
+      throw FormatException('Invalid annual date format', s);
+    }
+    var month = int.parse(parts[0]);
+    var day = int.parse(parts[1]);
+    return AnnualDate(month, day);
+  }
+
   /// Gets the month of year.
   int get month => _value.month;
 
@@ -150,5 +167,23 @@ class AnnualDate implements Comparable<AnnualDate> {
   /// Returns: true if the [this] is later than or equal to [rhs], false otherwise.
   bool operator >=(AnnualDate rhs) {
     return compareTo(rhs) >= 0;
+  }
+
+  /// Constructs an instance for the given json string with format MM-dd, in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  ///
+  /// * [FormatException]: The string is not in the correct format.
+  /// * [ArgumentOutOfRangeException]: The parameters do not form a valid date.
+  /// (February 29th is considered valid.)
+  factory AnnualDate.fromJson(String json) {
+    return AnnualDate.parse(json);
+  }
+
+  /// Returns a json [String] that represents this instance.
+  ///
+  /// The value of the current instance, in the form MM-dd.
+  String toJson() {
+    return toString();
   }
 }

--- a/lib/src/dayofweek.dart
+++ b/lib/src/dayofweek.dart
@@ -63,4 +63,8 @@ class DayOfWeek {
 
     return null;
   }
+
+  String toJson() => toString();
+
+  static DayOfWeek? fromJson(String json) => parse(json)!;
 }

--- a/lib/src/localdate.dart
+++ b/lib/src/localdate.dart
@@ -589,5 +589,13 @@ class LocalDate implements Comparable<LocalDate> {
   /// culture to obtain a format provider.
   @override String toString([String? patternText, Culture? culture]) =>
       LocalDatePatterns.format(this, patternText, culture);
-}
 
+  /// Constructs an instance for the given json string with format 'yyyy-MM-dd', in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  factory LocalDate.fromJson(String json) =>
+      LocalDatePattern.iso.parse(json).getValueOrThrow();
+
+  /// Returns a json [String] that represents this instance with format 'yyyy-MM-dd' format, in the ISO calendar.
+  String toJson() => LocalDatePattern.iso.format(this);
+}

--- a/lib/src/localdatetime.dart
+++ b/lib/src/localdatetime.dart
@@ -690,4 +690,13 @@ class LocalDateTime implements Comparable<LocalDateTime> {
   /// culture to obtain a format provider.
   @override String toString([String? patternText, Culture? culture]) =>
       LocalDateTimePatterns.format(this, patternText, culture);
+
+  /// Constructs an instance for the given json string with format 'yyyy-MM-ddTHH:mm:ss.FFFFFFFFF', in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  factory LocalDateTime.fromJson(String json) =>
+      LocalDateTimePattern.extendedIso.parse(json).getValueOrThrow();
+
+  /// Returns a json [String] that represents this instance with format 'yyyy-MM-ddTHH:mm:ss.FFFFFFFFF' format, in the ISO calendar.
+  String toJson() => LocalDateTimePattern.extendedIso.format(this);
 }

--- a/lib/src/localtime.dart
+++ b/lib/src/localtime.dart
@@ -426,4 +426,13 @@ class LocalTime implements Comparable<LocalTime> {
   /// or null to use the current isolate's culture.
   @override String toString([String? patternText, Culture? culture]) =>
       LocalTimePatterns.format(this, patternText, culture);
+
+  /// Constructs an instance for the given json string with format 'HH:mm:ss;FFFFFFFFF', in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  factory LocalTime.fromJson(String json) =>
+      LocalTimePattern.extendedIso.parse(json).getValueOrThrow();
+
+  /// Returns a json [String] that represents this instance with format 'HH:mm:ss.FFFFFFFFF' format, in the ISO calendar.
+  String toJson() => LocalTimePattern.extendedIso.format(this);
 }

--- a/lib/src/offset_date.dart
+++ b/lib/src/offset_date.dart
@@ -116,4 +116,13 @@ class OffsetDate
   /// culture to obtain a format provider.
   @override String toString([String? patternText, Culture? culture]) =>
       OffsetDatePatterns.format(this, patternText, culture);
+
+  /// Constructs an instance for the given json string with format ISO-8601, in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  factory OffsetDate.fromJson(String json) =>
+      OffsetDatePattern.generalIso.parse(json).getValueOrThrow();
+
+  /// Returns a json [String] that represents this instance with format ISO-8601 format, in the ISO calendar.
+  String toJson() => OffsetDatePattern.generalIso.format(this);
 }

--- a/lib/src/offset_datetime.dart
+++ b/lib/src/offset_datetime.dart
@@ -299,6 +299,15 @@ class OffsetDateTime {
   @override String toString([String? patternText, Culture? culture]) =>
       OffsetDateTimePatterns.format(this, patternText, culture);
 
+  /// Constructs an instance for the given json string with format ISO-8601, in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  factory OffsetDateTime.fromJson(String json) =>
+      OffsetDateTimePattern.extendedIso.parse(json).getValueOrThrow();
+
+  /// Returns a json [String] that represents this instance with format ISO-8601, in the ISO calendar.
+  String toJson() => OffsetDateTimePattern.extendedIso.format(this);
+
   /// Adds a duration to an offset date and time.
   ///
   /// * [offsetDateTime]: The value to add the duration to.

--- a/lib/src/offset_time.dart
+++ b/lib/src/offset_time.dart
@@ -95,4 +95,13 @@ class OffsetTime {
   /// or null to use the current isolate's culture.
   @override String toString([String? patternText, Culture? culture]) =>
       OffsetTimePatterns.format(this, patternText, culture);
+
+    /// Constructs an instance for the given json string with format ISO-8601, in the ISO calendar.
+  ///
+  /// * [json]: The json string to parse.
+  factory OffsetTime.fromJson(String json) =>
+      OffsetTimePattern.extendedIso.parse(json).getValueOrThrow();
+
+  /// Returns a json [String] that represents this instance with format ISO-8601, in the ISO calendar.
+  String toJson() => OffsetTimePattern.extendedIso.format(this);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 # https://github.com/flutter/flutter/blob/master/packages/flutter_test/pubspec.yaml
 dependencies:
   meta: "^1.3.0"
-#  quiver_hashcode: "^1.0.0"
-#  collection: "^1.14.10"
+  #  quiver_hashcode: "^1.0.0"
+  #  collection: "^1.14.10"
   collection: "^1.15.0"
 #  resource: "^2.1.6"
 #  flutter:
@@ -29,7 +29,6 @@ dev_dependencies:
   http: "^0.13.1"
   path: "^1.8.0"
   xml: "^5.0.2"
-
 # Flutter Testing
 #  test: "^0.12.3"
 #  matcher: "^0.12.2+1"

--- a/test/annual_date_test.dart
+++ b/test/annual_date_test.dart
@@ -84,3 +84,21 @@ void ToStringTest()
   expect('12-01', AnnualDate(12, 1).toString());
   expect('12-20', AnnualDate(12, 20).toString());
 }
+
+@Test()
+void ToJsonTest()
+{
+  expect('02-01', AnnualDate(2, 1).toJson());
+  expect('02-10', AnnualDate(2, 10).toJson());
+  expect('12-01', AnnualDate(12, 1).toJson());
+  expect('12-20', AnnualDate(12, 20).toJson());
+}
+
+@Test()
+void FromJsonTest()
+{
+  expect(AnnualDate(2, 1), AnnualDate.fromJson('02-01'));
+  expect(AnnualDate(2, 10), AnnualDate.fromJson('02-10'));
+  expect(AnnualDate(12, 1), AnnualDate.fromJson('12-01'));
+  expect(AnnualDate(12, 20), AnnualDate.fromJson('12-20'));
+}

--- a/test/localdate_test.dart
+++ b/test/localdate_test.dart
@@ -60,3 +60,21 @@ void MinIsoValue()
   expect(CalendarSystem.iso, value.calendar);
   expect(() => value.addDays(-1), throwsRangeError);
 }
+
+@Test()
+void ToJsonTest()
+{
+  expect(LocalDate(2020, 2, 1).toJson(), '2020-02-01');
+  expect(LocalDate(2020, 2, 10).toJson(), '2020-02-10');
+  expect(LocalDate(2020, 12, 1).toJson(), '2020-12-01');
+  expect(LocalDate(2020, 12, 20).toJson(), '2020-12-20');
+}
+
+@Test()
+void FromJsonTest()
+{
+  expect(LocalDate.fromJson('2020-02-01'), LocalDate(2020, 2, 1));
+  expect(LocalDate.fromJson('2020-02-10'), LocalDate(2020, 2, 10));
+  expect(LocalDate.fromJson('2020-12-01'), LocalDate(2020, 12, 1));
+  expect(LocalDate.fromJson('2020-12-20'), LocalDate(2020, 12, 20));
+}

--- a/test/localdatetime_test.dart
+++ b/test/localdatetime_test.dart
@@ -502,4 +502,20 @@ void MinMax_SameCalendar()
 //  });
 //}
 
+@Test()
+void ToJsonTest()
+{
+  expect(LocalDateTime(2020, 2, 1, 12, 0, 28).toJson(), '2020-02-01T12:00:28');
+  expect(LocalDateTime(2020, 2, 10, 0, 10, 0).toJson(), '2020-02-10T00:10:00');
+  expect(LocalDateTime(2020, 12, 1, 23, 29, 40).toJson(), '2020-12-01T23:29:40');
+  expect(LocalDateTime(2020, 12, 20, 11, 9, 19).toJson(), '2020-12-20T11:09:19');
+}
 
+@Test()
+void FromJsonTest()
+{
+  expect(LocalDateTime.fromJson('2020-02-01T12:00:28'), LocalDateTime(2020, 2, 1, 12, 0, 28));
+  expect(LocalDateTime.fromJson('2020-02-10T00:10:00'), LocalDateTime(2020, 2, 10, 0, 10, 0));
+  expect(LocalDateTime.fromJson('2020-12-01T23:29:40'), LocalDateTime(2020, 12, 1, 23, 29, 40));
+  expect(LocalDateTime.fromJson('2020-12-20T11:09:19'), LocalDateTime(2020, 12, 20, 11, 9, 19));
+}

--- a/test/localtime_test.dart
+++ b/test/localtime_test.dart
@@ -81,3 +81,21 @@ void WithOffset()
   expect(expected, time.withOffset(offset));
 }
 
+
+@Test()
+void ToJsonTest()
+{
+  expect(LocalTime(12, 0, 28).toJson(), '12:00:28');
+  expect(LocalTime(0, 10, 0).toJson(), '00:10:00');
+  expect(LocalTime(23, 29, 40).toJson(), '23:29:40');
+  expect(LocalTime(11, 9, 19).toJson(), '11:09:19');
+}
+
+@Test()
+void FromJsonTest()
+{
+  expect(LocalTime.fromJson('12:00:28'), LocalTime(12, 0, 28));
+  expect(LocalTime.fromJson('00:10:00'), LocalTime(0, 10, 0));
+  expect(LocalTime.fromJson('23:29:40'), LocalTime(23, 29, 40));
+  expect(LocalTime.fromJson('11:09:19'), LocalTime(11, 9, 19));
+}

--- a/test/offset_date_test.dart
+++ b/test/offset_date_test.dart
@@ -143,3 +143,20 @@ void ToString_NoFormat()
 
 */
 
+@Test()
+void ToJsonTest()
+{
+  expect(OffsetDate(LocalDate(2020, 2, 1), Offset.zero).toJson(), '2020-02-01Z');
+  expect(OffsetDate(LocalDate(2020, 2, 10), Offset.hours(2)).toJson(), '2020-02-10+02');
+  expect(OffsetDate(LocalDate(2020, 12, 1), Offset.zero).toJson(), '2020-12-01Z');
+  expect(OffsetDate(LocalDate(2020, 12, 20), Offset.hours(-7)).toJson(), '2020-12-20-07');
+}
+
+@Test()
+void FromJsonTest()
+{
+  expect(OffsetDate.fromJson('2020-02-01Z'), OffsetDate(LocalDate(2020, 2, 1), Offset.zero));
+  expect(OffsetDate.fromJson('2020-02-10+02'), OffsetDate(LocalDate(2020, 2, 10), Offset.hours(2)));
+  expect(OffsetDate.fromJson('2020-12-01+00:00'), OffsetDate(LocalDate(2020, 12, 1), Offset.zero));
+  expect(OffsetDate.fromJson('2020-12-20-07:00'), OffsetDate(LocalDate(2020, 12, 20), Offset.hours(-7)));
+}

--- a/test/offset_datetime_test.dart
+++ b/test/offset_datetime_test.dart
@@ -511,3 +511,20 @@ void ToOffsetTime()
   expect(expected, odt.toOffsetTime());
 }
 
+@Test()
+void ToJsonTest()
+{
+  expect(OffsetDateTime(LocalDateTime(2020, 2, 1, 12, 0, 28), Offset.zero).toJson(), '2020-02-01T12:00:28Z');
+  expect(OffsetDateTime(LocalDateTime(2020, 2, 10, 0, 10, 0), Offset.hours(2)).toJson(), '2020-02-10T00:10:00+02');
+  expect(OffsetDateTime(LocalDateTime(2020, 12, 1, 23, 29, 40), Offset.zero).toJson(), '2020-12-01T23:29:40Z');
+  expect(OffsetDateTime(LocalDateTime(2020, 12, 20, 11, 9, 19), Offset.hours(-7)).toJson(), '2020-12-20T11:09:19-07');
+}
+
+@Test()
+void FromJsonTest()
+{
+  expect(OffsetDateTime.fromJson('2020-02-01T12:00:28Z'), OffsetDateTime(LocalDateTime(2020, 2, 1, 12, 0, 28), Offset.zero));
+  expect(OffsetDateTime.fromJson('2020-02-10T00:10:00+02'), OffsetDateTime(LocalDateTime(2020, 2, 10, 0, 10, 0), Offset.hours(2)));
+  expect(OffsetDateTime.fromJson('2020-12-01T23:29:40+00:00'), OffsetDateTime(LocalDateTime(2020, 12, 1, 23, 29, 40), Offset.zero));
+  expect(OffsetDateTime.fromJson('2020-12-20T11:09:19-07:00'), OffsetDateTime(LocalDateTime(2020, 12, 20, 11, 9, 19), Offset.hours(-7)));
+}

--- a/test/offset_time_test.dart
+++ b/test/offset_time_test.dart
@@ -130,3 +130,20 @@ void ToString_NoFormat() {
   }
 }
 
+@Test()
+void ToJsonTest()
+{
+  expect(OffsetTime(LocalTime(12, 0, 28), Offset.zero).toJson(), '12:00:28Z');
+  expect(OffsetTime(LocalTime(0, 10, 0), Offset.hours(2)).toJson(), '00:10:00+02');
+  expect(OffsetTime(LocalTime(23, 29, 40), Offset.zero).toJson(), '23:29:40Z');
+  expect(OffsetTime(LocalTime(11, 9, 19), Offset.hours(-7)).toJson(), '11:09:19-07');
+}
+
+@Test()
+void FromJsonTest()
+{
+  expect(OffsetTime.fromJson('12:00:28Z'), OffsetTime(LocalTime(12, 0, 28), Offset.zero));
+  expect(OffsetTime.fromJson('00:10:00+02'), OffsetTime(LocalTime(0, 10, 0), Offset.hours(2)));
+  expect(OffsetTime.fromJson('23:29:40+00:00'), OffsetTime(LocalTime(23, 29, 40), Offset.zero));
+  expect(OffsetTime.fromJson('11:09:19-07:00'), OffsetTime(LocalTime(11, 9, 19), Offset.hours(-7)));
+}


### PR DESCRIPTION
Added implementations for `toJson` and `fromJson` methods for the following types:
- `LocalDate`
- `LocalDateTime`
- `LocalTime`
- `OffsetDate`
- `OffsetDateTime`
- `OffsetTime`
- `DayOfWeek`

These methods allow to use `time_machine` types along with `json_serializable` and could be useful to integrate those types with REST API clients for example.